### PR TITLE
Adding confirmatory test for using LuceneQueryComponent to select valid indexes only

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpressionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpressionVisitor.java
@@ -1,0 +1,122 @@
+/*
+ * IndexFieldVisitor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.metadata.MetaDataException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Visitor pattern for visiting KeyExpressions as they are being created in an index
+ */
+public interface KeyExpressionVisitor {
+
+    KeyExpression visitField(FieldKeyExpression fke);
+
+    KeyExpression visitThen(ThenKeyExpression thenKey);
+
+    KeyExpression visitNestingKey(NestingKeyExpression nke);
+
+    KeyExpression visitGroupingKey(GroupingKeyExpression gke);
+
+    boolean applies(String indexType);
+
+    default KeyExpression visit(KeyExpression ke) {
+        if (ke instanceof FieldKeyExpression) {
+            return visitField((FieldKeyExpression)ke);
+        } else if (ke instanceof ThenKeyExpression) {
+            return visitThen((ThenKeyExpression)ke);
+        } else if (ke instanceof NestingKeyExpression) {
+            return visitNestingKey((NestingKeyExpression)ke);
+        } else if (ke instanceof GroupingKeyExpression) {
+            return visitGroupingKey((GroupingKeyExpression)ke);
+        } else {
+            throw new MetaDataException("Cannot visit KeyExpression of type <" + ke + ">");
+        }
+    }
+
+    public interface Factory {
+        KeyExpressionVisitor createVisitor();
+    }
+
+    public static class Registry {
+        private static final Registry INSTANCE = new Registry();
+
+        @Nullable
+        private volatile List<KeyExpressionVisitor> functions;
+
+        private Registry() {
+            // Will be initialized the first time a builder is requested
+            functions = null;
+        }
+
+        @Nonnull
+        public static Registry instance() {
+            return INSTANCE;
+        }
+
+        public List<KeyExpressionVisitor> visitors() {
+            return initOrGetRegistry();
+        }
+
+        @Nonnull
+        private List<KeyExpressionVisitor> initOrGetRegistry() {
+            // The reference to the registry is copied into a local variable to avoid referencing the
+            // volatile multiple times
+            List<KeyExpressionVisitor> currRegistry = functions;
+            if (currRegistry != null) {
+                return currRegistry;
+            }
+            synchronized (this) {
+                currRegistry = functions;
+                if (currRegistry == null) {
+                    // Create the registry
+                    List<KeyExpressionVisitor> newRegistry = initRegistry();
+                    functions = newRegistry;
+                    return newRegistry;
+                } else {
+                    // Another thread created the registry for us
+                    return currRegistry;
+                }
+            }
+        }
+
+        @Nonnull
+        private static List<KeyExpressionVisitor> initRegistry() {
+            try {
+                List<KeyExpressionVisitor> functions = new LinkedList<>();
+                for (KeyExpressionVisitor.Factory factory : ServiceLoader.load(KeyExpressionVisitor.Factory.class)) {
+                    functions.add(factory.createVisitor());
+                }
+                return new CopyOnWriteArrayList<>(functions);
+            } catch (ServiceConfigurationError err) {
+                throw new RecordCoreException("Unable to load all defined FunctionKeyExpressions", err);
+            }
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/PrefixableExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/PrefixableExpression.java
@@ -1,0 +1,26 @@
+/*
+ * PrefixedExpression.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+public interface PrefixableExpression extends KeyExpression {
+
+    void prefix(String prefix);
+}

--- a/fdb-record-layer-core/src/test/proto/test_records_text.proto
+++ b/fdb-record-layer-core/src/test/proto/test_records_text.proto
@@ -34,12 +34,16 @@ message SimpleDocument {
 
 // The primary key is set in the test.
 message ComplexDocument {
-    optional int64 group = 1;
-    optional int64 doc_id = 2;
-    optional string text = 3;
-    repeated string tag = 4;
-    optional int32 score = 5;
-    optional string text2 = 6;
+    message Header {
+        optional int64 header_id = 1;
+    }
+    optional Header header = 1;
+    optional int64 group = 2;
+    optional int64 doc_id = 3;
+    optional string text = 4;
+    repeated string tag = 5;
+    optional int32 score = 6;
+    optional string text2 = 7;
 }
 
 message MapDocument {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFieldKeyExpression.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFieldKeyExpression.java
@@ -1,5 +1,5 @@
 /*
- * LuceneFieldKeyExpression.java
+ * TypedFieldKeyExpression.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -22,13 +22,12 @@ package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
-import org.apache.lucene.document.Field;
 
 import javax.annotation.Nonnull;
 
-public class LuceneFieldKeyExpression extends FieldKeyExpression implements LuceneKeyExpression{
+public class LuceneFieldKeyExpression extends FieldKeyExpression implements LuceneKeyExpression {
 
-    private LuceneKeyExpression.FieldType type;
+    private FieldType type;
     private boolean sorted;
     private boolean stored;
     private boolean isPrefixed = false;
@@ -46,18 +45,20 @@ public class LuceneFieldKeyExpression extends FieldKeyExpression implements Luce
 
     public LuceneFieldKeyExpression(@Nonnull final String field, @Nonnull final FieldType type,
                                     @Nonnull final boolean sorted, @Nonnull final boolean stored) throws DeserializationException {
-        super(field, FanType.None, Key.Evaluated.NullStandin.NULL);
-        this.type = type;
-        this.sorted = sorted;
-        this.stored = stored;
+        this(field,FanType.None, Key.Evaluated.NullStandin.NULL,type,sorted,stored);
+    }
+
+    public LuceneFieldKeyExpression(@Nonnull final FieldKeyExpression original, @Nonnull final FieldType type,
+                                    @Nonnull final boolean sorted, @Nonnull final boolean stored) throws DeserializationException {
+        this(original.getFieldName(), original.getFanType(),original.getNullStandin(),type,sorted,stored);
     }
 
     public FieldType getType() {
         return type;
     }
 
-    public Field.Store isStored() {
-        return stored ? Field.Store.YES : Field.Store.NO;
+    public boolean isStored() {
+        return stored;
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -30,17 +30,12 @@ import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
-import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
 import com.apple.foundationdb.record.metadata.IndexRecordFunction;
 import com.apple.foundationdb.record.metadata.Key;
-import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
-import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBIndexableRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -51,20 +46,15 @@ import com.apple.foundationdb.record.provider.foundationdb.indexes.StandardIndex
 import com.apple.foundationdb.record.query.QueryToKeyMatcher;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Verify;
-import com.google.common.collect.Lists;
-import com.google.protobuf.Descriptors;
-import com.google.protobuf.GeneratedMessage;
 import com.google.protobuf.Message;
-import com.google.protobuf.ProtocolStringList;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StoredField;
-import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -75,9 +65,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -209,7 +197,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                 document.add(new IntPoint(fieldName, (Integer) value));
                 break;
             case STRING:
-                document.add(new TextField(fieldName, (String) value, expression.isStored()));
+                document.add(new TextField(fieldName, (String)value, expression.isStored() ? Field.Store.YES : Field.Store.NO));
                 break;
             default:
                 break;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -162,10 +162,13 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                             LuceneKeyExpression expression = fields.get(i);
                             if (expression instanceof LuceneThenKeyExpression) {
                                 int prefixLocation = ((LuceneThenKeyExpression)expression).getPrimaryKeyPosition();
-                                String prefix = entryKey.get(prefixLocation + i).toString().concat("_");
+                                final Object o = entryKey.get(prefixLocation + i);
+                                String prefix = o == null ? "" : o.toString().concat("_");
                                 List<LuceneFieldKeyExpression> children = ((LuceneThenKeyExpression)expression).getLuceneChildren();
                                 for (int j = 0; j < children.size(); j++) {
-                                    if (j == prefixLocation) continue;
+                                    if (j == prefixLocation) {
+                                        continue;
+                                    }
                                     LuceneFieldKeyExpression child = children.get(j);
                                     insertDocumentField(child, entryKey.get(i + offset + j), document, prefix);
                                 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneKeyExpression.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneKeyExpression.java
@@ -26,9 +26,9 @@ import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.google.common.collect.Lists;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -51,8 +51,8 @@ public interface LuceneKeyExpression extends KeyExpression {
      * For nested fields and possibly in the future more validation on fields + types and possibly field names.
      * Other possible things to check would be complexity and number of levels.
      * @return if the entire expression is validated as lucene compatible
+     * @param expression the expression to validate
      */
-
     public static boolean validateLucene(KeyExpression expression) {
         if (expression instanceof LuceneKeyExpression) {
             return true;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneKeyExpressionVisitorFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneKeyExpressionVisitorFactory.java
@@ -1,0 +1,32 @@
+/*
+ * LuceneKeyExpressionVisitorFactory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.metadata.expressions.KeyExpressionVisitor;
+import com.google.auto.service.AutoService;
+
+@AutoService(KeyExpressionVisitor.Factory.class)
+public class LuceneKeyExpressionVisitorFactory implements KeyExpressionVisitor.Factory {
+    @Override
+    public KeyExpressionVisitor createVisitor() {
+        return new LuceneTypeConverter();
+    }
+}

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneThenKeyExpression.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneThenKeyExpression.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,13 +39,17 @@ public class LuceneThenKeyExpression extends ThenKeyExpression implements Lucene
 
     public LuceneThenKeyExpression(@Nonnull final LuceneFieldKeyExpression primaryKey, @Nonnull final List<KeyExpression> children) {
         super(children);
-        if (!validate()) throw new IllegalArgumentException("failed to validate lucene compatibility on construction");
+        if (!validate()) {
+            throw new IllegalArgumentException("failed to validate lucene compatibility on construction");
+        }
         this.primaryKey = primaryKey;
 
     }
 
     public boolean validate() {
-        if (validated) return validated;
+        if (validated) {
+            return validated;
+        }
         validated = true;
         for (KeyExpression child : getChildren()) {
             validated = validated && child instanceof LuceneKeyExpression;
@@ -55,7 +58,7 @@ public class LuceneThenKeyExpression extends ThenKeyExpression implements Lucene
     }
 
     public void prefix(String prefix) {
-        if (!(isPrefixed)){
+        if (!(isPrefixed)) {
             for (LuceneFieldKeyExpression child : getLuceneChildren()) {
                 child.prefix(prefix);
             }
@@ -63,7 +66,7 @@ public class LuceneThenKeyExpression extends ThenKeyExpression implements Lucene
     }
 
     @Override
-    public List<KeyExpression> normalizeKeyForPositions(){
+    public List<KeyExpression> normalizeKeyForPositions() {
         return Lists.newArrayList(this);
     }
 
@@ -71,9 +74,7 @@ public class LuceneThenKeyExpression extends ThenKeyExpression implements Lucene
         return super.normalizeKeyForPositions().indexOf(primaryKey);
     }
 
-    public List<LuceneFieldKeyExpression> getLuceneChildren(){
-        List<LuceneFieldKeyExpression> children = getChildren().stream().map((e) -> (LuceneFieldKeyExpression)e )
-                .collect(Collectors.toList());
-        return children;
+    public List<LuceneFieldKeyExpression> getLuceneChildren() {
+        return getChildren().stream().map((e) -> (LuceneFieldKeyExpression)e).collect(Collectors.toList());
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneTypeConverter.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneTypeConverter.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpressionVisitor;
 import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.PrefixableExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
 
 import java.util.List;
@@ -50,12 +51,14 @@ public class LuceneTypeConverter implements KeyExpressionVisitor {
 
     @Override
     public KeyExpression visitNestingKey(final NestingKeyExpression nke) {
-        return new NestingKeyExpression((LuceneFieldKeyExpression)visit(nke.getParent()),visit(nke.getChild()));
+        PrefixableExpression pe = (PrefixableExpression)visit(nke.getChild());
+        pe.prefix(nke.getParent().getFieldName().concat("_"));
+        return pe;
     }
 
     @Override
     public KeyExpression visitGroupingKey(final GroupingKeyExpression gke) {
-        return new GroupingKeyExpression(visit(gke.getChild()),gke.getGroupedCount());
+        return new GroupingKeyExpression(visit(gke.getChild()), gke.getGroupedCount());
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneTypeConverter.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneTypeConverter.java
@@ -1,0 +1,55 @@
+/*
+ * LuceneTypeConverter.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.NestingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Converts from normal KeyExpression types to Lucene KE types.
+ */
+public class LuceneTypeConverter {
+
+    public static KeyExpression convert(KeyExpression original) {
+        if (original instanceof FieldKeyExpression) {
+            //TODO(bfines) get that information from somewhere in the index definition
+            return new LuceneFieldKeyExpression((FieldKeyExpression)original, LuceneKeyExpression.FieldType.STRING, true, true);
+        } else if (original instanceof ThenKeyExpression) {
+            List<KeyExpression> children = ((ThenKeyExpression)original).getChildren().stream()
+                    .map(LuceneTypeConverter::convert).collect(Collectors.toList());
+            return new LuceneThenKeyExpression((LuceneFieldKeyExpression)children.get(0), children);
+        } else if (original instanceof NestingKeyExpression) {
+            NestingKeyExpression nke = (NestingKeyExpression)original;
+            return new NestingKeyExpression((FieldKeyExpression)convert(nke.getParent()), convert(nke.getChild()));
+        } else if (original instanceof GroupingKeyExpression) {
+            KeyExpression child = convert(((GroupingKeyExpression)original).getChild());
+            return new GroupingKeyExpression(child, ((GroupingKeyExpression)original).getGroupedCount());
+        } else {
+            return original;
+        }
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
@@ -26,6 +26,8 @@ import com.apple.foundationdb.record.TestRecordsTextProto;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.text.AllSuffixesTextTokenizer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils;
@@ -59,10 +61,16 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 @Tag(Tags.RequiresFDB)
 public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
 
-    private final Index textIndex = new Index("Complex$text_index", field("text"), IndexTypes.LUCENE,
+    private final Index textIndex = new Index("Complex$text_index",
+            new LuceneFieldKeyExpression("text", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NULL, LuceneKeyExpression.FieldType.STRING,
+                    true,true),
+            IndexTypes.LUCENE,
             ImmutableMap.of(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, AllSuffixesTextTokenizer.NAME));
 
-    private final Index text2Index = new Index("Complex$text2_index", field("text2"), IndexTypes.LUCENE,
+    private final Index text2Index = new Index("Complex$text2_index",
+            new LuceneFieldKeyExpression("text2", KeyExpression.FanType.None, Key.Evaluated.NullStandin.NULL, LuceneKeyExpression.FieldType.STRING,
+                    true,true),
+            IndexTypes.LUCENE,
             ImmutableMap.of(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, AllSuffixesTextTokenizer.NAME));
 
     @Override


### PR DESCRIPTION
Here's a quick test that the correct index is selected when you pass the fields into `LuceneQueryComponent`

Writing this as a PR because I don't have push privileges for your private fork (shocking, I know :-P).